### PR TITLE
Removed redundant stop var declaration

### DIFF
--- a/demos/2d/kinematic_char/player.gd
+++ b/demos/2d/kinematic_char/player.gd
@@ -31,8 +31,6 @@ func _fixed_process(delta):
 
 	#create forces
 	var force = Vector2(0,GRAVITY)
-
-	var stop = velocity.x!=0.0
 	
 	var walk_left = Input.is_action_pressed("move_left")
 	var walk_right = Input.is_action_pressed("move_right")


### PR DESCRIPTION
Seems like var stop shouldn't be written twice. For the sake of clarity, I removed the first instance of it in the script.
